### PR TITLE
use 'One pair' instead of 'OnePair' in the hand histories

### DIFF
--- a/lib/Room/Schema/PokerNetwork/Result/Hands.pm
+++ b/lib/Room/Schema/PokerNetwork/Result/Hands.pm
@@ -126,6 +126,7 @@ sub format_hi_hand {
 
     switch ($best) {
       case 'NoPair' { $best = 'High card'; }
+      case 'OnePair' { $best = 'One pair'; }
       case 'TwoPair' { $best = 'Two pairs'; }
       case 'Trips' { $best = 'Three of a kind'; }
       case 'Straight' { $best = 'Straight'; }


### PR DESCRIPTION
Hand histories show:
  Seat 3: dooglus showed [8s 8c Ah Qc 9h] and won ($1.48) with OnePair

This patch changes it to show:
  Seat 3: dooglus showed [8s 8c Ah Qc 9h] and won ($1.48) with One pair

I posted a bug report about this, but can't see a way of tying it to this pull request.

Did I do it wrong?
