### PR TITLE
proposed fix for issue #11

### DIFF
--- a/root/static/js/jquery.jpoker.js
+++ b/root/static/js/jquery.jpoker.js
@@ -489,13 +489,13 @@
         },
 
         SHORT: function(chips) {
-            if(chips < 10) {
-                return this.LONG(chips);
-            }
             var unit = [ 'G', 'M', 'K', '' ];
             for(var magnitude = 1000000000; magnitude > 0; magnitude /= 1000) {
                 if(chips >= magnitude) {
                     if(chips / magnitude < 10) {
+                        chips = chips / ( magnitude / 100 );
+                        return parseInt(chips / 100, 10) + this.fraction + parseInt((chips/10) % 10, 10) + parseInt(chips % 10, 10) + unit[0];
+                    } else if(chips / magnitude < 100) {
                         chips = chips / ( magnitude / 10 );
                         return parseInt(chips / 10, 10) + this.fraction + parseInt(chips % 10, 10) + unit[0];
                     } else {


### PR DESCRIPTION
Always show 3 significant digits in the SHORT format, without going into the 3rd decimal place:
  0.67, 6.78, 67.8, 678, 6.78K, 67.8K, 678K, 6.78M, etc.

With this fix, we'll see:
2 decimal places up to 10 chips,
1 decimal place between 10 and 100 chips,
0 decimal places for 100 to 1000 chips.

Then for 1000 to 10k chips we'll go back to 2 decimal places, then 1, then 0:
1.23K,
12.3K
123K
