### PR TITLE
Add 2-legged OAuth 1.0 PPN API

### DIFF
--- a/lib/ppn/pokernetwork/apiclient.py
+++ b/lib/ppn/pokernetwork/apiclient.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python
+# coding: utf-8
+
+import optparse
+import sys
+import time
+import urllib2
+
+import oauth2
+
+
+class RequestError(Exception):
+    pass
+
+
+def build_request(url, key, secret, method='GET'):
+    """Returns a signed HMAC_SHA1 oauth2.Request object."""
+    consumer = oauth2.Consumer(key=key, secret=secret)
+    params = {
+        'oauth_version': "1.0",
+        'oauth_nonce': oauth2.generate_nonce(),
+        'oauth_timestamp': int(time.time()),
+        'oauth_consumer_key': consumer.key
+    }
+
+    req = oauth2.Request(method=method, url=url, parameters=params)
+    signature_method = oauth2.SignatureMethod_HMAC_SHA1()
+    req.sign_request(signature_method, consumer, None)
+    return req
+
+
+def perform_api_request(url, key, secret):
+    request = build_request(url, key, secret)
+    request_url = request.to_url()
+
+    print 'REQUEST:', urllib2.unquote(request_url)
+
+    response_code = 200
+    response_data = None
+    try:
+        u = urllib2.urlopen(request_url)
+        response_data = u.read()
+    except urllib2.HTTPError, e:
+        response_code = e.code
+        response_data = e.read()
+    except urllib2.URLError, e:
+        raise RequestError(e)
+
+    print 'RESPONSE: [%d] %s' % (response_code, response_data)
+
+
+if __name__ == '__main__':
+    usage = '%prog [OPTIONS] URL'
+    parser = optparse.OptionParser(usage=usage)
+    parser.add_option('-k', '--key', dest='key', metavar='API_KEY',
+                      help='required')
+    parser.add_option('-s', '--secret', dest='secret', metavar='SECRET',
+                      help='required')
+    options, args = parser.parse_args()
+    try:
+        url = args[0]
+        key = options.key
+        secret = options.secret
+    except Exception, e:
+        parser.print_help()
+        print e
+        sys.exit(1)
+
+    perform_api_request(url, key, secret)

--- a/lib/ppn/pokernetwork/apikeygen.py
+++ b/lib/ppn/pokernetwork/apikeygen.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python
+# coding: utf-8
+
+
+import sys
+sys.path.insert(0, ".")
+sys.path.insert(0, "..")
+
+import optparse
+import random
+import string
+
+from pokernetwork import apiserver, pokerdatabase, pokernetworkconfig
+
+API_KEY_LENGTH = 50
+API_SECRET_LENGTH = 50
+ALPHABET = string.ascii_uppercase + string.ascii_lowercase + string.digits
+
+
+def _generate_random_string(length, alphabet):
+    return ''.join(random.choice(alphabet) for x in range(length))
+
+
+def _load_config(configpath):
+    config = pokernetworkconfig.Config([''])
+    config.load(configpath)
+    if not config.header:
+        raise RuntimeError('Could not load config: %s' % configpath)
+    return config
+
+
+def generate_key_secret_pair():
+    key = _generate_random_string(API_KEY_LENGTH, ALPHABET)
+    secret = _generate_random_string(API_SECRET_LENGTH, ALPHABET)
+    return key, secret
+
+
+if __name__ == '__main__':
+    usage = """%prog [OPTIONS] EMAIL SERVER_CONFIG
+    Generates an API key and secret for a given user EMAIL, and saves the result
+    to the pokerserver database as specified in SERVER_CONFIG"""
+    parser = optparse.OptionParser(usage=usage)
+    options, args = parser.parse_args()
+    try:
+        email = args[0]
+        configpath = args[1]
+    except Exception, e:
+        parser.print_help()
+        sys.exit(1)
+
+    config = _load_config(configpath)
+    db = pokerdatabase.PokerDatabase(config)
+
+    api_user_store = apiserver.APIUserStore(db)
+
+    key, secret = generate_key_secret_pair()
+    api_user_store.add_user(email, key, secret)
+
+    print """\
+    The following API user has been added:
+
+    email: %s
+    key: %s
+    secret: %s
+
+    Please store this information in a safe location.""" % (email, key, secret)

--- a/lib/ppn/pokernetwork/apiserver.py
+++ b/lib/ppn/pokernetwork/apiserver.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python
+# coding: utf-8
+
+from contextlib import closing
+from functools import wraps
+import json
+
+import oauth2
+
+from twisted.python import log
+from twisted.web import http, resource
+
+
+class APIUserStore(object):
+    SCHEMA = """CREATE TABLE IF NOT EXISTS `api_users` (
+      `id` int(11) NOT NULL AUTO_INCREMENT,
+      `email` varchar(255) NOT NULL,
+      `api_key` varchar(255) NOT NULL,
+      `secret` varchar(255) NOT NULL,
+      PRIMARY KEY (`id`),
+      UNIQUE KEY `key_secret` (`api_key`,`secret`)
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8;"""
+
+    def __init__(self, db):
+        self.db = db
+        self.__create_table_if_not_exists()
+
+    def __create_table_if_not_exists(self):
+        with closing(self.db.cursor()) as cursor:
+            cursor.execute(self.SCHEMA)
+            self.db.commit()
+
+    def get_secret(self, api_key):
+        """
+        Returns the secret corresponding to `key` or None if `key` is not found.
+        """
+        with closing(self.db.cursor()) as cursor:
+            cursor.execute('SELECT secret FROM api_users WHERE api_key=%s',
+                           (api_key,))
+            row = cursor.fetchone()
+            if row:
+                return row[0]
+            return None
+
+    def get_users(self):
+        """
+        Returns a list of dictionaries containing the following keys: id,
+        email, key, secret.
+        """
+        with closing(self.db.cursor()) as cursor:
+            cursor.execute('SELECT id, email, api_key, secret FROM api_users')
+            return cursor.fetchall()
+
+    def add_user(self, email, api_key, secret):
+        with closing(self.db.cursor()) as cursor:
+            cursor.execute('INSERT INTO api_users (email, api_key, secret) '
+                           'VALUES (%s, %s, %s)', (email, api_key, secret))
+            self.db.commit()
+
+    def remove_users_by_email(self, email):
+        with closing(self.db.cursor()) as cursor:
+            cursor.execute('DELETE FROM api_users WHERE email=%s', (email,))
+            self.db.commit()
+
+    def remove_user_by_key(self, api_key):
+        with closing(self.db.cursor()) as cursor:
+            cursor.execute('DELETE FROM api_users WHERE api_key=%s',
+                           (api_key,))
+            self.db.commit()
+
+
+def _JSON_response(request, status_code, json_obj):
+    request.setResponseCode(status_code)
+    result_string = json.dumps(json_obj)
+    request.setHeader('Content-Type', 'application/json; charset=UTF-8')
+    request.setHeader('Cache-Control', 'no-store')
+    request.setHeader('Pragma', 'no-cache')
+    return result_string
+
+
+class OAuthResource(resource.Resource):
+    """
+    Represents a 2-legged OAuth 1.0 protected Resource. When using 2-legged
+    OAuth, you do not need to provide an OAuth access token to access
+    a resource.
+
+    Each request must be properly signed using the `HMAC-SHA1` signature method.
+
+    See the OAuth 1.0 Protocol spec: http://tools.ietf.org/html/rfc5849
+    """
+    oauth_server = oauth2.Server(
+        signature_methods={'HMAC-SHA1': oauth2.SignatureMethod_HMAC_SHA1()})
+
+
+    def __init__(self, secret_store):
+        resource.Resource.__init__(self)
+        self.secret_store = secret_store
+
+    def _validate_request(self, request):
+        """
+        Validates a 2-legged OAuth 1.0 twisted.web.http.Request object.
+
+        Parameters are accepeted as GET/POST arguments, or in the Authorization
+        header.
+        """
+        url = str(request.URLPath())
+        headers = dict(request.requestHeaders.getAllRawHeaders()),
+
+        args = {}
+        for key, values in request.args.iteritems():
+            if len(values) > 1:
+                # error: argument keys cannot be repeated!
+                raise KeyError('request argument %s cannot be repeated' % key)
+            args[key] = values[0]
+
+        oauth_request = oauth2.Request.from_request(request.method, url,
+                                                    headers=headers,
+                                                    parameters=args)
+
+        key = args['oauth_consumer_key']
+        secret = self.secret_store.get_secret(key)
+        if secret is None:
+            raise oauth2.Error('Invalid Consumer Key')
+
+        consumer = oauth2.Consumer(key=key, secret=secret)
+        self.oauth_server.verify_request(oauth_request, consumer, None)
+
+    def _oauth_protect(render_method):
+        """Decorates this Resource's render method to protect against
+        unauthorized access."""
+        @wraps(render_method)
+        def wrapper(self, request):
+            try:
+                self._validate_request(request)
+                return render_method(self, request)
+            except (oauth2.MissingSignature, ValueError, KeyError), e:
+                status = http.BAD_REQUEST
+                return _JSON_response(request, status,
+                                      {'error': 'bad_request',
+                                       'status': status})
+            except oauth2.Error:
+                status = http.UNAUTHORIZED
+                return _JSON_response(request, status,
+                                      {'error': 'unauthorized',
+                                       'status': status})
+            except:
+                log.err()
+                status = http.INTERNAL_SERVER_ERROR
+                return _JSON_response(request, status,
+                                      {'error': 'internal_server_error',
+                                       'status': status})
+        return wrapper
+
+    @_oauth_protect
+    def render(self, request):
+        """Render code used from
+        http://twistedmatrix.com/trac/browser/tags/releases/twisted-11.0.0/twisted/web/resource.py
+        """
+        m = getattr(self, 'render_' + request.method, None)
+        if not m:
+            from twisted.web.error import UnsupportedMethod
+            allowedMethods = (getattr(self, 'allowedMethods', 0) or
+                              resource._computeAllowedMethods(self))
+            raise UnsupportedMethod(allowedMethods)
+        return m(request)
+
+
+class RefreshTableConfig(OAuthResource):
+    isLeaf = True
+
+    def __init__(self, api_service, secret_store):
+        OAuthResource.__init__(self, secret_store)
+        self.api_service = api_service
+
+    def render_GET(self, request):
+        self.api_service.refresh_table_config()
+        return ''
+
+
+class Root(resource.Resource):
+    def __init__(self, api_service, secret_store):
+        resource.Resource.__init__(self)
+        self.putChild('refresh_table_config',
+                      RefreshTableConfig(api_service, secret_store))
+

--- a/lib/ppn/pokernetwork/apiservice.py
+++ b/lib/ppn/pokernetwork/apiservice.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python
+# coding: utf-8
+
+
+class Error(RuntimeError):
+    pass
+
+
+class APIService(object):
+    """A wrapper around pokernetwork.pokerservice.PokerService for
+    pokernetwork.apiserver.APIServer to use."""
+
+    def __init__(self, poker_service):
+        self.poker_service = poker_service
+
+    def get_active_tables(self):
+        """Returns a list of pokernetwork.pokertable.PokerTable objects
+        corresponding to tables that currently have players seated."""
+        active_tables = []
+        for _, table in self.poker_service.tables.iteritems():
+            if len(table.listPlayers()) > 0:
+                active_tables.append(table)
+        return active_tables
+
+    def add_table(self, table_settings):
+        pass
+
+    def remove_table(self, table_name):
+        pass
+
+    def reload_server_config(self):
+        """
+        Reloads and returns the current pokernetwork.pokernetworkconfig.Config.
+        """
+        config = self.poker_service.settings
+        config.reload()
+        return config
+
+    def refresh_table_config(self):
+        """
+        Reloads the server config then performs the following algorithm:
+
+            For each table that has no seated players:
+                - If the table is not listed in the config, delete the table.
+                - Otherwise, update the table settings to the settings in the
+                  config.
+        """
+        config = self.reload_server_config()
+
+        config_tables = {table['name']: table for table in
+                         config.headerGetProperties('/server/table')}
+
+        active_table_names = set()
+        tables_to_delete = []
+        for table_id, table in self.poker_service.tables.iteritems():
+            table_name = table.game.name
+            if len(table.listPlayers()) > 0:
+                active_table_names.add(table_name)
+            elif table_name not in config_tables:
+                tables_to_delete.append(table_id)
+
+        for table_id in tables_to_delete:
+            self.poker_service.deleteTable(self.poker_service.tables[table_id])
+
+        for table_name, table_settings in config_tables.iteritems():
+            if table_name not in active_table_names:
+                self.poker_service.createTable(0, table_settings)

--- a/lib/ppn/pokernetwork/pokerdatabase.py
+++ b/lib/ppn/pokernetwork/pokerdatabase.py
@@ -134,7 +134,7 @@ class PokerDatabase:
 
     def error(self, string):
         self.message("*ERROR* " + string)
-        
+
     def close(self):
         if hasattr(self, 'db'):
             self.db.close()
@@ -159,7 +159,7 @@ class PokerDatabase:
         if cursor.rowcount not in (0, 1):
             raise ExceptionUpgradeFailed, "%s: changed %d rows, expected one or zero" % ( sql, cursor.rowcount )
         cursor.close()
-        
+
     def checkVersion(self):
         if version != self.version:
             self.message("database version %s must be the same as the poker-network version %s" % ( self.version, version ))
@@ -190,6 +190,11 @@ class PokerDatabase:
 
     def getVersion(self):
         return self.version
+
+    def commit(self):
+        """If the database and the tables support transactions, this commits the
+        current transaction; otherwise it does nothing."""
+        return self.db.commit()
 
     def cursor(self, *args, **kwargs):
         return self.db.cursor(*args, **kwargs)

--- a/lib/ppn/pokernetwork/pokerservice.py
+++ b/lib/ppn/pokernetwork/pokerservice.py
@@ -148,7 +148,7 @@ class PokerService(service.Service):
 
     implements(IPokerService)
 
-    def __init__(self, settings):
+    def __init__(self, settings, db):
         if type(settings) is StringType:
             settings_object = pokernetworkconfig.Config(['.'])
             settings_object.doc = libxml2.parseMemory(settings, len(settings))
@@ -200,7 +200,7 @@ class PokerService(service.Service):
             self.refill = refill[0]
         else:
             self.refill = None
-        self.db = None
+        self.db = db
         self.cashier = None
         self.poker_auth = None
         self.timer = {}
@@ -245,7 +245,7 @@ class PokerService(service.Service):
             packet.game_id = 0
         cursor.close()
         return packet
-        
+
     def setupTourneySelectInfo(self):
         #
         # load module that provides additional tourney information
@@ -264,10 +264,9 @@ class PokerService(service.Service):
                 s = None
             self.tourney_select_info = module.Handle(self, s)
             getattr(self.tourney_select_info, '__call__')
-            
+
     def startService(self):
         self.monitors = []
-        self.db = PokerDatabase(self.settings)
         self.setupTourneySelectInfo()
         self.setupLadder()
         self.setupResthost()
@@ -431,7 +430,7 @@ class PokerService(service.Service):
         outputStr = "Aces"
         try:
             # I am not completely sure poker-engine should be hardcoded here like this...
-            transObj = gettext.translation('poker-engine', 
+            transObj = gettext.translation('poker-engine',
                                                 languages=[lang], codeset=codeset)
             transObj.install()
             myGetTextFunc = transObj.gettext
@@ -946,12 +945,12 @@ class PokerService(service.Service):
                         player.tourneys.remove(tourney.serial)
             self.tourneyDeleteRouteActual(tourney.serial)
         self.timer[key] = reactor.callLater(max(self._ping_delay*2, wait*2), doTourneyDeleteRoute)
-        
+
     def tourneyDeleteRouteActual(self, tourney_serial):
         cursor = self.db.cursor()
         cursor.execute("DELETE FROM route WHERE tourney_serial = %s", tourney_serial)
         cursor.close()
-    
+
     def tourneyGameFilled(self, tourney, game):
         table = self.getTable(game.id)
         cursor = self.db.cursor()
@@ -1065,13 +1064,13 @@ class PokerService(service.Service):
                 break
         if found:
             if found.state != TOURNAMENT_STATE_REGISTERING:
-                self.error("tourney %d is a satellite of %d but %d is in state %s instead of the expected state %s" % 
+                self.error("tourney %d is a satellite of %d but %d is in state %s instead of the expected state %s" %
                            ( tourney.serial, found.schedule_serial, found.schedule_serial, found.state, TOURNAMENT_STATE_REGISTERING) )
                 return ( 0, TOURNAMENT_STATE_REGISTERING )
             return ( found.serial, None )
         else:
             return ( 0, False )
-                
+
     def tourneySatelliteSelectPlayer(self, tourney, serial, rank):
         if tourney.satellite_of == 0:
             return False
@@ -1091,7 +1090,7 @@ class PokerService(service.Service):
         if registrations <= 0:
             return False
         serials = filter(lambda serial: serial not in tourney.satellite_registrations, tourney.winners)
-        for serial in serials: 
+        for serial in serials:
             packet = PacketPokerTourneyRegister(serial = serial, game_id = tourney.satellite_of)
             if self.tourneyRegister(packet = packet, via_satellite = True):
                 tourney.satellite_registrations.append(serial)
@@ -1147,7 +1146,7 @@ class PokerService(service.Service):
         for row in cursor.fetchall():
             self.getPage('http://' + row['host'] + ':' + str(row['port']) + '/TOURNEY_START?tourney_serial=' + tourney_serial)
         cursor.close()
-        
+
     def tourneyNotifyStart(self, tourney_serial):
         manager = self.tourneyManager(tourney_serial)
         if manager.type != PACKET_POKER_TOURNEY_MANAGER:
@@ -1166,7 +1165,7 @@ class PokerService(service.Service):
                 if user2properties.has_key(str(avatar.getSerial())) and avatar.explain:
                     calls.append(reactor.callLater(0.01, send, avatar))
         return calls
-        
+
     def tourneyManager(self, tourney_serial):
         packet = PacketPokerTourneyManager()
         packet.tourney_serial = tourney_serial
@@ -1291,7 +1290,7 @@ class PokerService(service.Service):
             return self.tourney_select_info(self, packet, tourneys)
         else:
             return None
-    
+
     def tourneyRegister(self, packet, via_satellite = False):
         serial = packet.serial
         tourney_serial = packet.game_id
@@ -1316,7 +1315,7 @@ class PokerService(service.Service):
             for avatar in avatars:
                 avatar.sendPacketVerbose(error)
             return False
-            
+
         if tourney.isRegistered(serial):
             error = PacketError(other_type = PACKET_POKER_TOURNEY_REGISTER,
                                 code = PacketPokerTourneyRegister.ALREADY_REGISTERED,
@@ -1904,7 +1903,7 @@ class PokerService(service.Service):
                 self.message(message)
             cursor2 = self.db.cursor()
             cursor2.execute("REPLACE INTO route VALUES (0,%s,%s,%s)", ( row['serial'], int(seconds()), self.resthost_serial))
-            cursor2.close()            
+            cursor2.close()
         cursor.close()
 
     def getMoney(self, serial, currency_serial):
@@ -2602,7 +2601,24 @@ class PokerService(service.Service):
             tourney_serial = description['tourney'].serial
 
         cursor = self.db.cursor()
-        sql = "INSERT pokertables ( resthost_serial, seats, player_timeout, muck_timeout, currency_serial, name, variant, betting_structure, skin, tourney_serial ) VALUES ( %s, %s, %s, %s, %s, %s,  %s, %s, %s, %s ) " % self.db.literal((
+
+        sql = """INSERT INTO pokertables \
+        (resthost_serial, seats, player_timeout, muck_timeout, currency_serial,
+         name, variant, betting_structure, skin, tourney_serial)
+         VALUES (%s, %s, %s, %s, %s, %s,  %s, %s, %s, %s)
+         ON DUPLICATE KEY UPDATE
+            serial=LAST_INSERT_ID(serial),
+            resthost_serial=VALUES(resthost_serial),
+            seats=VALUES(seats),
+            player_timeout=VALUES(player_timeout),
+            muck_timeout=VALUES(muck_timeout),
+            currency_serial=VALUES(currency_serial),
+            name=VALUES(name),
+            variant=VALUES(variant),
+            betting_structure=VALUES(betting_structure),
+            skin=VALUES(skin),
+            tourney_serial=VALUES(tourney_serial)
+        """ % self.db.literal((
             self.resthost_serial,
             description['seats'],
             description.get('player_timeout', 60),
@@ -2613,12 +2629,26 @@ class PokerService(service.Service):
             description['betting_structure'],
             description.get('skin', 'default'),
             tourney_serial ))
+
         if self.verbose > 1:
             self.message("createTable: %s" % sql)
+
         cursor.execute(sql)
-        if cursor.rowcount != 1:
-            self.error("inserted %d rows (expected 1): %s " % ( cursor.rowcount, sql ))
-            # FIXME: sr #2273 notes that this should return None from right here if rowcount == 0
+
+        # From: http://dev.mysql.com/doc/refman/5.1/en/insert-on-duplicate.html
+        # With ON DUPLICATE KEY UPDATE, the affected-rows value per row is 1 if
+        # the row is inserted as a new row and 2 if an existing row is updated.
+        #
+        # cursor.rowcount represents the number of inserted rows, which will be
+        # 0 when a row is updated (the table already exists), or 1 when a new
+        # row is inserted (the table does not exist).
+        if cursor.rowcount == 0:
+            self.message('updated row in pokertables for table %s'
+                         % description['name'])
+        elif cursor.rowcount == 1:
+            self.message('inserted row into pokertables for table %s'
+                         % description['name'])
+
         if hasattr(cursor, "lastrowid"):
             id = cursor.lastrowid
         else:

--- a/lib/ppn/tests/test_apiserver.py
+++ b/lib/ppn/tests/test_apiserver.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python
+# coding: utf-8
+
+from twisted.internet.defer import succeed
+from twisted.trial import unittest
+from twisted.web import http, server
+from twisted.web.test.test_web import DummyRequest
+
+from pokernetwork import apiclient
+from pokernetwork.apiserver import OAuthResource
+
+
+class DummyHTTPHeaders:
+    def getAllRawHeaders(self):
+        return []
+
+
+class OAuthRequest(DummyRequest):
+    def __init__(self):
+        DummyRequest.__init__(self, [''])
+        self.requestHeaders = DummyHTTPHeaders()
+
+
+    def URLPath(self):
+        return self.uri
+
+
+def _build_dummy_request(key, secret, method='GET'):
+    dummy_request = OAuthRequest()
+    oauth2_request = apiclient.build_request(dummy_request.uri, key, secret,
+                                             method)
+    print 'OAuth2 signed URL:\n', oauth2_request.to_url()
+    for arg, value in oauth2_request.iteritems():
+        dummy_request.addArg(arg, value)
+    print 'Dummy URLPath:\n', dummy_request.URLPath()
+    return dummy_request
+
+
+class MockAPISecretStore(object):
+    def __init__(self, secrets):
+        self.secrets = secrets
+
+
+    def get_secret(self, key):
+        if key in self.secrets:
+            return self.secrets[key]
+        return None
+
+
+class MockOAuthResource(OAuthResource):
+    def __init__(self, secret_store):
+        OAuthResource.__init__(self, secret_store)
+
+    def render_GET(self, request):
+        request.setResponseCode(http.OK)
+        return "success"
+
+
+def _render(resource, request):
+    result = resource.render(request)
+    if isinstance(result, str):
+        request.write(result)
+        request.finish()
+        return succeed(None)
+    elif result is server.NOT_DONE_YET:
+        if request.finished:
+            return succeed(None)
+        else:
+            return request.notifyFinish()
+    else:
+        raise ValueError("Unexpected return value: %r" % (result,))
+
+
+class OAuthResourceTests(unittest.TestCase):
+    def setUp(self):
+        self.key = 'some_key'
+        self.secret = 'some_secret'
+        secret_store = MockAPISecretStore({self.key: self.secret})
+        self.resource = MockOAuthResource(secret_store)
+
+
+    def _test_request(self, request, expected_status_code):
+        d = _render(self.resource, request)
+
+        def rendered(ignored):
+            self.assertEquals(request.responseCode, expected_status_code)
+
+        d.addCallback(rendered)
+        return d
+
+
+    def test_successful_oauth_request(self):
+        request = _build_dummy_request(self.key, self.secret)
+        return self._test_request(request, http.OK)
+
+
+    def test_bad_oauth_request(self):
+        return self._test_request(OAuthRequest(), http.BAD_REQUEST)
+
+
+    def test_unauthorized_oauth_request_bad_secret(self):
+        request = _build_dummy_request(self.key, 'bad_secret')
+        return self._test_request(request, http.UNAUTHORIZED)
+
+
+    def test_unauthorized_oauth_request_bad_key(self):
+        request = _build_dummy_request('bad_key', self.secret)
+        self.resource.render(request)
+        self.assertEquals(request.responseCode, http.UNAUTHORIZED)
+


### PR DESCRIPTION
- Add APIServer to handle 2-legged OAuth 1.0 requests (apiserver.py)
- Add "/refresh_table_config" API request handler to APIServer
- Add APIService to perform refresh_table_config task (apiservice.py)
- Add API key generator (apikeygen.py)
- Add API client to perform API requests from the command line (apiclient.py)
- Add apiserver tests to lib/ppn/tests
- Modify PokerService createTable() to perform an ON DUPLICATE KEY UPDATE
- Add database param (PokerDatabase) to PokerService **init**
- Minor changes to pokerdatabase, pokerserver, pokerservice
- Use MySQL as an API key store
