### PR TITLE
Load additional table configs from /etc/poker-network/tables.d

### DIFF
--- a/lib/ppn/pokernetwork/apiservice.py
+++ b/lib/ppn/pokernetwork/apiservice.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 # coding: utf-8
 
+from pokernetwork import tableconfigutils
+
 
 class Error(RuntimeError):
     pass
@@ -28,27 +30,26 @@ class APIService(object):
     def remove_table(self, table_name):
         pass
 
-    def reload_server_config(self):
-        """
-        Reloads and returns the current pokernetwork.pokernetworkconfig.Config.
-        """
-        config = self.poker_service.settings
-        config.reload()
-        return config
-
     def refresh_table_config(self):
         """
-        Reloads the server config then performs the following algorithm:
+        Create/modify/delete tables at runtime, by loading table descriptions
+        (XML <table /> nodes) from the server config and table configs.
 
-            For each table that has no seated players:
-                - If the table is not listed in the config, delete the table.
-                - Otherwise, update the table settings to the settings in the
-                  config.
+        Gets table descriptions from the server config and table configs, then
+        performs the following algorithm:
+
+            For each active table that has NO seated players:
+                - If the table has no associated table description, then delete
+                  it.
+                - Otherwise, modify the table's attributes to match its
+                  associated table description.
+
+            For each table description, d:
+                - If a table with name d['name'] is not running on the server,
+                  then create it.
         """
-        config = self.reload_server_config()
-
         config_tables = {}
-        for table in config.headerGetProperties('/server/table'):
+        for table in self.poker_service.get_table_descriptions():
             config_tables[table['name']] = table
 
         active_table_names = set()
@@ -63,6 +64,6 @@ class APIService(object):
         for table_id in tables_to_delete:
             self.poker_service.deleteTable(self.poker_service.tables[table_id])
 
-        for table_name, table_settings in config_tables.iteritems():
+        for table_name, table_description in config_tables.iteritems():
             if table_name not in active_table_names:
-                self.poker_service.createTable(0, table_settings)
+                self.poker_service.createTable(0, table_description)

--- a/lib/ppn/pokernetwork/pokerservice.py
+++ b/lib/ppn/pokernetwork/pokerservice.py
@@ -96,6 +96,7 @@ from pokernetwork import pokeravatar
 from pokernetwork.user import User
 from pokernetwork import pokercashier
 from pokernetwork import pokernetworkconfig
+from pokernetwork import tableconfigutils
 from pokerauth import get_auth_instance
 from datetime import date
 
@@ -265,6 +266,9 @@ class PokerService(service.Service):
             self.tourney_select_info = module.Handle(self, s)
             getattr(self.tourney_select_info, '__call__')
 
+    def get_table_descriptions(self):
+        return tableconfigutils.get_table_descriptions(self.settings)
+
     def startService(self):
         self.monitors = []
         self.setupTourneySelectInfo()
@@ -314,8 +318,10 @@ class PokerService(service.Service):
             except locale.Error, le:
                 self.error('Unable to restore original locale: %s' % le)
 
-        for description in self.settings.headerGetProperties("/server/table"):
-            self.createTable(0, description)
+        table_descriptions = self.get_table_descriptions()
+        for table_description in table_descriptions:
+            self.createTable(0, table_description)
+
         self.cleanupTourneys()
         self.updateTourneysSchedule()
         self.messageCheck()
@@ -2667,7 +2673,7 @@ class PokerService(service.Service):
         return table
 
     def cleanupCrashedTables(self):
-        for description in self.settings.headerGetProperties("/server/table"):
+        for description in self.get_table_descriptions():
             self.cleanupCrashedTable("pokertables.name = %s" % self.db.literal((description['name'],)))
         self.cleanupCrashedTable("pokertables.resthost_serial = %d" % self.resthost_serial)
 

--- a/lib/ppn/pokernetwork/tableconfigutils.py
+++ b/lib/ppn/pokernetwork/tableconfigutils.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python
+# coding: utf-8
+
+import glob
+import os
+
+from pokernetwork import pokernetworkconfig
+
+
+DEFAULT_TABLE_CONFIGS_DIR = '/etc/poker-network/tables.d'
+DEFAULT_TABLE_NODE_XPATH = '/*/table'
+
+
+def __get_tables(config, table_node_xpath=DEFAULT_TABLE_NODE_XPATH):
+    return config.headerGetProperties(table_node_xpath)
+
+
+def parse_table_config(table_config_path,
+                       table_node_xpath=DEFAULT_TABLE_NODE_XPATH):
+    """
+    Parses table properties from the XML config specified by
+    `table_config_path`. Tables are represented as XML nodes and specified by
+    the XPath expression, `table_node_xpath`. Table properties are XML
+    attributes. nodes specified by the XPath expression, `table_node_xpath`.
+
+    Here is an example of a table config consisting of 2 table nodes, with
+    table_node_xpath of '/tables/table':
+
+        <?xml version="1.0" encoding="UTF-8"?>
+        <tables>
+            <table name="Table1" variant="holdem" betting_structure=".05-.10-no-limit" seats="6" />
+            <table name="Table2" variant="omaha8" betting_structure="10-20-limit" seats="10" />
+        </tables>
+
+    Returns a list of dicts with keys corresponding to table properties (name,
+    variant, betting_structure, seats, etc.).
+    """
+    config = pokernetworkconfig.Config([''])
+    config.load(table_config_path)
+    return config.headerGetProperties(table_node_xpath)
+
+
+def parse_table_configs(table_configs_dir=DEFAULT_TABLE_CONFIGS_DIR,
+                        table_node_xpath=DEFAULT_TABLE_NODE_XPATH):
+    """
+    Parses table configs found in `table_configs_dir`.
+
+    Returns a list of dicts with keys corresponding to table properties (name,
+    variant, betting_structure, seats, etc.).
+
+    `table_configs_dir`: directory containing table configuration files
+    `table_node_xpath`: the XPath expression used to find table nodes in each
+                        config file
+    """
+    tables = []
+    table_config_paths = glob.glob(os.path.join(table_configs_dir, '*.xml'))
+    for table_config_path in table_config_paths:
+        tables.extend(parse_table_config(table_config_path))
+    return tables
+
+
+def merge_tables(server_config_tables, table_config_tables):
+    """
+    Merges server_config_tables with table_config_tables.
+
+    When a table with the same name is found in both the server config and
+    a table config, we use the table settings from the table config. In
+    other words, table entries in table configs take precedence over table
+    entries in the server config.
+
+    Returns a list of dictionaries with keys corresponding to table
+    properties (name, variant, seats, etc.).
+
+    `server_config_tables`: a list of dictionaries with keys corresponding
+                            to table properties (name, variant, seats,
+                            etc.)
+    `table_config_tables`: a list of dictionaries with keys corresponding
+                           to table properties (name, variant, seats,
+                           etc.)
+    """
+    tables = {}
+    for table in table_config_tables:
+        tables[table['name']] = table
+
+    for table in server_config_tables:
+        table_name = table['name']
+        if table_name not in tables:
+            tables[table_name] = table
+
+    return tables.values()
+
+
+def get_table_descriptions(server_config,
+                           table_configs_dir=DEFAULT_TABLE_CONFIGS_DIR,
+                           table_node_xpath=DEFAULT_TABLE_NODE_XPATH):
+    """
+    Combines table descriptions in `server_config` with table config files
+    located in `table_configs_dir`. Table descriptions in table config files
+    take precedence over table descriptions in the server config.
+
+    Returns a list of dicts with keys corresponding to table properties (name,
+    variant, betting_structure, seats, etc.).
+
+    `server_config`: a pokernetwork.pokernetworkconfig.Config object
+    `table_configs_dir`: directory containing XML table configuration files
+    `table_node_xpath`: the XPath expression used to find table nodes in each
+                        config file
+    """
+    if server_config.path:
+        server_config.reload()
+
+    server_config_tables = __get_tables(server_config)
+    table_config_tables = parse_table_configs(table_configs_dir)
+    return merge_tables(server_config_tables, table_config_tables)

--- a/lib/ppn/tests/test_tableconfigutils.py
+++ b/lib/ppn/tests/test_tableconfigutils.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python
+# coding: utf-8
+
+import os
+import tempfile
+import unittest
+
+from pokernetwork import tableconfigutils
+
+
+SERVER_CONFIG_TEMPLATE = """\
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<server xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="server.xsd" poker_network_version="2.0.0">
+%s
+</server>"""
+
+
+TABLE_CONFIG_TEMPLATE = """\
+<?xml version="1.0" encoding="UTF-8"?>
+<tables>
+%s
+</tables>"""
+
+
+TABLE_NODE_TEMPLATE = """\
+<table name="%(name)s" variant="%(variant)s" betting_structure="%(betting_structure)s" seats="%(seats)s" />"""
+
+
+SERVER_CONFIG_TABLES = [
+    ('One', 'holdem', '5-10-no-limit'),
+    ('Two', 'omaha', '2-4-limit'),
+    ('Four', 'omaha8', '.01-.02-pot-limit'),
+    ('Ten', 'stud', '10-20-limit'),
+    ('Eleven', 'stud', '30-60-limit')
+]
+
+
+TABLE_CONFIGS = {
+    'holdem.limit.xml': [('One', 'holdem', '2-4-limit'),
+                         ('Two', 'holdem', '10-20-limit')],
+    'holdem.no-limit.xml': [('Three', 'holdem', '.02-.04-no-limit'),
+                            ('Four', 'holdem', '.05-.10-no-limit', '6'),
+                            ('Five', 'holdem', '100-200-no-limit')],
+    'omaha.limit.xml': [('Six', 'omaha', '2-4-limit'),
+                        ('Seven', 'omaha', '10-20-limit', '8')],
+    'omaha8.limit.xml': [('Eight', 'omaha8', '20-40-limit'),
+                         ('Nine', 'omaha8', '5-10-limit')]
+}
+
+
+# result of merging SERVER_CONFIG_TABLES with tables in TABLE_CONFIGS
+MERGED_TABLES = [
+    ('One', 'holdem', '2-4-limit'),
+    ('Two', 'holdem', '10-20-limit'),
+    ('Three', 'holdem', '.02-.04-no-limit'),
+    ('Four', 'holdem', '.05-.10-no-limit', '6'),
+    ('Five', 'holdem', '100-200-no-limit'),
+    ('Six', 'omaha', '2-4-limit'),
+    ('Seven', 'omaha', '10-20-limit', '8'),
+    ('Eight', 'omaha8', '20-40-limit'),
+    ('Nine', 'omaha8', '5-10-limit'),
+    ('Ten', 'stud', '10-20-limit'),
+    ('Eleven', 'stud', '30-60-limit')
+]
+
+
+def create_table_dict(name, variant, betting_structure, seats='10'):
+    return {'name': name, 'variant': variant,
+            'betting_structure': betting_structure, 'seats': seats}
+
+
+def create_table_xml_entry(table_properties):
+    return TABLE_NODE_TEMPLATE % table_properties
+
+
+def create_config(config_template, tables):
+    table_xml_entries = []
+    for table in tables:
+        table_properties = create_table_dict(*table)
+        table_xml_entries.append(create_table_xml_entry(table_properties))
+    return config_template % '\n'.join(table_xml_entries)
+
+
+class DummyServerConfig():
+    def __init__(self, table_descriptions,
+                 table_node_xpath=tableconfigutils.DEFAULT_TABLE_NODE_XPATH):
+        self.path = None
+        self.table_descriptions = table_descriptions
+        self.table_node_xpath = table_node_xpath
+
+    def reload(self):
+         pass
+
+    def headerGetProperties(self, name):
+        if name is self.table_node_xpath:
+            return self.table_descriptions
+        return []
+
+
+class TableConfigUtilsTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.config_basedir = tempfile.mkdtemp()
+        cls.server_config_path = os.path.join(cls.config_basedir,
+                                              'poker.server.xml')
+        with open(cls.server_config_path, 'w+t') as server_config:
+            contents = create_config(SERVER_CONFIG_TEMPLATE,
+                                     SERVER_CONFIG_TABLES)
+            server_config.write(contents)
+
+        cls.table_configs_dir = os.path.join(cls.config_basedir, 'tables.d')
+        os.mkdir(cls.table_configs_dir)
+
+        cls.table_config_paths = []
+        for config_filename, tables in TABLE_CONFIGS.iteritems():
+            config_path = os.path.join(cls.table_configs_dir, config_filename)
+            cls.table_config_paths.append(config_path)
+            with open(config_path, 'w+t') as table_config:
+                contents = create_config(TABLE_CONFIG_TEMPLATE, tables)
+                table_config.write(contents)
+
+    @classmethod
+    def tearDownClass(cls):
+        for config_path in cls.table_config_paths:
+            os.remove(config_path)
+        os.removedirs(cls.table_configs_dir)
+
+    def test_parse_table_config(self):
+        tables = tableconfigutils.parse_table_config(self.server_config_path)
+        assert len(tables) == len(SERVER_CONFIG_TABLES)
+
+    def test_parse_table_configs(self):
+        tables = tableconfigutils.parse_table_configs(self.table_configs_dir)
+        assert len(tables) == sum(len(tables) for tables in
+                                  TABLE_CONFIGS.values())
+
+    def _compare_tables(self, tables_a, tables_b):
+        """
+        Returns True if both lists of tables contain the same table entries
+        (order is not important).
+
+        `tables_a`: a list of dicts containing table properties as keys
+        `tables_b`: a list of dicts containing table properties as keys
+        """
+        if len(tables_a) != len(tables_b):
+            return False
+
+        seen = {}
+        for table in tables_a:
+            seen[table['name']] = table
+
+        for table in tables_b:
+            table_name = table['name']
+            if table_name not in seen or table != seen[table_name]:
+                return False
+        return True
+
+    def test_merge_tables_with_no_tables(self):
+        assert tableconfigutils.merge_tables([], []) == []
+
+    def test_merge_tables_with_no_server_config_tables(self):
+        table_config_tables = [
+            create_table_dict('One', 'holdem', '2-4-limit'),
+            create_table_dict('Two', 'holdem', '5-10-no-limit'),
+            create_table_dict('Three', 'omaha8', '3-6-limit')
+        ]
+        merged_tables = tableconfigutils.merge_tables([], table_config_tables)
+        assert self._compare_tables(merged_tables, table_config_tables)
+
+    def test_merge_tables_with_no_table_config_tables(self):
+        server_config_tables = [
+            create_table_dict('One', 'holdem', '2-4-limit'),
+            create_table_dict('Two', 'holdem', '5-10-no-limit'),
+            create_table_dict('Five', 'omaha', '.10-.20-pot-limit'),
+            create_table_dict('Six', 'omaha8', '3-6-limit')
+        ]
+        merged_tables = tableconfigutils.merge_tables(server_config_tables, [])
+        assert self._compare_tables(merged_tables, server_config_tables)
+
+    def test_get_all_table_descriptions(self):
+        server_config_tables = [create_table_dict(*table) for table in
+                                SERVER_CONFIG_TABLES]
+        server_config = DummyServerConfig(server_config_tables)
+        table_descriptions = tableconfigutils.get_table_descriptions(
+                                server_config, self.table_configs_dir)
+
+        expected_tables = [create_table_dict(*table) for table in MERGED_TABLES]
+
+        assert self._compare_tables(table_descriptions, expected_tables)


### PR DESCRIPTION
Table descriptions are normally loaded from the server config (defaults to
`/etc/poker-network/poker.server.xml`). This update allows additional table
descriptions to loaded from table configs located in
`/etc/poker-network/tables.d`. Table descriptions from table configs take
precedence over table descriptions in the server config.

Here is an example table config file:

```
<?xml version="1.0" encoding="UTF-8"?>
<tables>
  <table name="SomeTable" variant="holdem" betting_structure=".5-.10-no-limit" seats="6" player_timeout="60" currency_serial="1"/>
  <table name="SomeOtherTable" variant="holdem" betting_structure="50-100-limit" seats="10" player_timeout="60" currency_serial="1"/>
</tables>
```

Notice the `<table />` node  structure remains unchanged from the server config, 
and the root node  is `<tables>` instead of `<server>`).
