### PR TITLE
Issue #65: Add "Broadcast Message" feature to API

### DIFF
--- a/lib/ppn/pokernetwork/apiserver.py
+++ b/lib/ppn/pokernetwork/apiserver.py
@@ -69,9 +69,9 @@ class APIUserStore(object):
             self.db.commit()
 
 
-def _JSON_response(request, status_code, json_obj):
+def _JSON_response(request, status_code=http.OK, response_dict={}):
     request.setResponseCode(status_code)
-    result_string = json.dumps(json_obj)
+    result_string = json.dumps(response_dict, separators=(',', ':'))
     request.setHeader('Content-Type', 'application/json; charset=UTF-8')
     request.setHeader('Cache-Control', 'no-store')
     request.setHeader('Pragma', 'no-cache')
@@ -104,7 +104,7 @@ class OAuthResource(resource.Resource):
         header.
         """
         url = str(request.URLPath())
-        headers = dict(request.requestHeaders.getAllRawHeaders()),
+        headers = dict(request.requestHeaders.getAllRawHeaders())
 
         args = {}
         for key, values in request.args.iteritems():
@@ -133,22 +133,18 @@ class OAuthResource(resource.Resource):
             try:
                 self._validate_request(request)
                 return render_method(self, request)
-            except (oauth2.MissingSignature, ValueError, KeyError), e:
+            except (oauth2.MissingSignature, ValueError, KeyError):
                 status = http.BAD_REQUEST
-                return _JSON_response(request, status,
-                                      {'error': 'bad_request',
-                                       'status': status})
+                return _JSON_response(request, status, {'error': 'bad_request'})
             except oauth2.Error:
                 status = http.UNAUTHORIZED
-                return _JSON_response(request, status,
-                                      {'error': 'unauthorized',
-                                       'status': status})
+                return _JSON_response(request, status, {'error':
+                                                        'unauthorized'})
             except:
                 log.err()
                 status = http.INTERNAL_SERVER_ERROR
                 return _JSON_response(request, status,
-                                      {'error': 'internal_server_error',
-                                       'status': status})
+                                      {'error': 'internal_server_error'})
         return wrapper
 
     @_oauth_protect
@@ -158,11 +154,25 @@ class OAuthResource(resource.Resource):
         """
         m = getattr(self, 'render_' + request.method, None)
         if not m:
-            from twisted.web.error import UnsupportedMethod
             allowedMethods = (getattr(self, 'allowedMethods', 0) or
                               resource._computeAllowedMethods(self))
-            raise UnsupportedMethod(allowedMethods)
+
+            status = http.NOT_ALLOWED
+            description = 'Unsupported method. Allowed methods: %s' \
+                              % str(allowedMethods)
+            json = {'error': 'method_not_allowed',
+                    'error_description': description}
+            request.setHeader('Allow', ', '.join(allowedMethods))
+            return _JSON_response(request, status, json)
         return m(request)
+
+
+def get_json_request_body(request):
+    """
+    Deserializes the request's body into a Python object. See the documentation
+    for json.loads: http://docs.python.org/library/json.html
+    """
+    return json.loads(request.content.read())
 
 
 class RefreshTableConfig(OAuthResource):
@@ -174,7 +184,51 @@ class RefreshTableConfig(OAuthResource):
 
     def render_GET(self, request):
         self.api_service.refresh_table_config()
-        return ''
+        return _JSON_response(request)
+
+
+class BroadcastMessageToPlayerSerial(OAuthResource):
+    def __init__(self, player_serial, api_service, secret_store):
+        OAuthResource.__init__(self, secret_store)
+        self.api_service = api_service
+        self.player_serial = player_serial
+
+    def render_POST(self, request):
+        json_request_body = get_json_request_body(request)
+        message = json_request_body['message']
+        success = self.api_service.broadcast_to_player(message,
+                                                       self.player_serial)
+        if success:
+            return _JSON_response(request)
+        description = 'Could not broadcast message to player with serial %s'\
+                            % self.player_serial
+        response = {'error': 'bad_request', 'error_description': description}
+        return _JSON_response(request, http.BAD_REQUEST, response)
+
+
+class BroadcastMessageToPlayer(OAuthResource):
+    def __init__(self, api_service, secret_store):
+        OAuthResource.__init__(self, secret_store)
+        self.api_service = api_service
+
+    def getChild(self, name, request):
+        player_serial = int(name)
+        return BroadcastMessageToPlayerSerial(player_serial, self.api_service,
+                                              self.secret_store)
+
+
+class BroadcastMessage(OAuthResource):
+    def __init__(self, api_service, secret_store):
+        OAuthResource.__init__(self, secret_store)
+        self.api_service = api_service
+        self.putChild('player', BroadcastMessageToPlayer(api_service,
+                                                         secret_store))
+
+    def render_POST(self, request):
+        json_request_body = get_json_request_body(request)
+        message = json_request_body['message']
+        self.api_service.broadcast_to_all(message)
+        return _JSON_response(request)
 
 
 class Root(resource.Resource):
@@ -182,4 +236,6 @@ class Root(resource.Resource):
         resource.Resource.__init__(self)
         self.putChild('refresh_table_config',
                       RefreshTableConfig(api_service, secret_store))
+        self.putChild('broadcast',
+                      BroadcastMessage(api_service, secret_store))
 

--- a/lib/ppn/pokernetwork/apiservice.py
+++ b/lib/ppn/pokernetwork/apiservice.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # coding: utf-8
 
-from pokernetwork import tableconfigutils
+import pokerpackets
 
 
 class Error(RuntimeError):
@@ -14,6 +14,20 @@ class APIService(object):
 
     def __init__(self, poker_service):
         self.poker_service = poker_service
+
+    def broadcast_to_all(self, message):
+        """
+        Broadcasts a PacketPokerMessage packet to all clients.
+        """
+        packet = pokerpackets.PacketPokerMessage(string=message)
+        self.poker_service.broadcast_to_all(packet)
+
+    def broadcast_to_player(self, message, player_serial):
+        """
+        Broadcasts a PacketPokerMessage packet to a specific player.
+        """
+        packet = pokerpackets.PacketPokerMessage(string=message)
+        return self.poker_service.broadcast_to_player(packet, player_serial)
 
     def get_active_tables(self):
         """Returns a list of pokernetwork.pokertable.PokerTable objects

--- a/root/static/js/jquery.jpoker.js
+++ b/root/static/js/jquery.jpoker.js
@@ -1252,6 +1252,9 @@
                 server.spawnTable(server, packet);
                 break;
 
+                // The server sends a PacketPokerMessage when broadcasting
+                // informative announcements to players, such as scheduled
+                // maintenance.
                 case 'PacketPokerMessage':
                 case 'PacketPokerGameMessage':
                 jpoker.dialog(packet.string);


### PR DESCRIPTION
# Overview

To broadcast a message, the server sends a PacketPokerMessage packet to the
client. The client then displays the message in a jpoker.dialog() window.
# API resources that were added
## Broadcast a message to all players

```
POST /broadcast
```
### Parameters:
- **message** - **string** _required_
### Example request body:

```
{"message": "Hello, players"}
```
### Example request with apiclient:

```
python apiclient.py -k '<API_KEY>' -s '<SECRET>' -b '{"message": "Hello, players"}' https://localhost:8880/broadcast
```
## Broadcast a message to a specific player

```
POST /broadcast/player/:serial
```
### Parameters
- `message` - **string** _required_
### Example request body:

```
{"message": "Hello, player"}
```
### Example request with apiclient:

```
python apiclient.py -k '<API_KEY>' -s '<SECRET>' -b '{"message": "Hello, player"}' https://localhost:8880/broadcast/player/2
```
# Other notable changes:
- Modify apiclient to allow for POST requests by specifying a request body
