### PR TITLE
Allow JS console message to be displayed in Firefox 5.0

### DIFF
--- a/root/static/js/jquery.jpoker.js
+++ b/root/static/js/jquery.jpoker.js
@@ -189,7 +189,7 @@
         console : window.console,
 
         message: function(str) {
-            if(jpoker.console) { jpoker.console.log(str); }
+            if(jpoker.console) { console.log(str); }
         },
 
         dialog_options: { width: '300px', height: 'auto', autoOpen: false, dialog: true, title: 'jpoker message'},


### PR DESCRIPTION
`window.console.log()` does not work in Firefox 5.0, so I've replaced it with `console.log()`. `console.log()` also works in Chrome 12.0. I have not tested other browsers.
